### PR TITLE
Improve email input to fit centered ui

### DIFF
--- a/Neos.IdentityServer 2.2/Neos.IdentityServer.MultiFactor/Neos.IdentityServer.MultiFactor.AdapterPresentation.cs
+++ b/Neos.IdentityServer 2.2/Neos.IdentityServer.MultiFactor/Neos.IdentityServer.MultiFactor.AdapterPresentation.cs
@@ -1084,7 +1084,7 @@ namespace Neos.IdentityServer.MultiFactor
             {
                 result += "<input id=\"opt3\" name=\"opt\" type=\"radio\" value=\"2\" onchange=\"ChooseMethodChanged()\" " + ((method == PreferredMethod.Email) ? "checked=\"checked\"> " : "> ") + RuntimeAuthProvider.GetProvider(PreferredMethod.Email).GetUIChoiceLabel(usercontext) + "<br /><br />";
                 result += "<div>" + Resources.GetString(ResourcesLocaleKind.Html, "HtmlCHOOSEOptionEmailWarning") + "</div></br>";
-                result += "<input id=\"stmail\" name=\"stmail\" type=\"text\" class=\"text autoWidth\" disabled=\"disabled\" ><span class=\"text bigText\">" + MailUtilities.StripEmailDomain(usercontext.MailAddress) + "</span><br /><br />";
+                result += "<input id=\"stmail\" name=\"stmail\" type=\"text\" class=\"text fullWidth\" disabled=\"disabled\" placeholder=\"username" + MailUtilities.StripEmailDomain(usercontext.MailAddress) + "\"><br /><br />";
             }
 
             result += "<input id=\"opt5\" name=\"opt\" type=\"radio\" value=\"4\" onchange=\"ChooseMethodChanged()\"/> " + Resources.GetString(ResourcesLocaleKind.Html, "HtmlCHOOSEOptionNone") + "<br /><br />";


### PR DESCRIPTION
With the Microsoft [Centered UI Web Theme][1], the layout around the
email input concerning TOTP enrollment could be improved. For end-users
it's not clear what they should fill in, or where they should fill it
in.

This tries to improve the layout to work with both the centered ui and
the original ui theme.

This is what the TOTP enrollment step looks like with the center UI:
![mfaemail-centeredui-original](https://user-images.githubusercontent.com/135698/46129907-47998280-c238-11e8-8b78-939f77b6bc86.PNG)

Here is our proposed change in the center UI:
![mfaemail-centeredui-proposal_scaled](https://user-images.githubusercontent.com/135698/46129971-6d268c00-c238-11e8-88df-653b4eb69115.png)

This is how the proposed change looks like in the original layout:
![mfaemail-classicui-proposal_scaled](https://user-images.githubusercontent.com/135698/46130023-8b8c8780-c238-11e8-8ad1-17340bd5090e.png)



[1]:https://github.com/Microsoft/adfsWebCustomization/tree/master/centeredUi