### PR TITLE
Allow providing full e-mail address

### DIFF
--- a/Neos.IdentityServer 2.2/Neos.IdentityServer.MultiFactor/Neos.IdentityServer.MultiFactor.Provider.cs
+++ b/Neos.IdentityServer 2.2/Neos.IdentityServer.MultiFactor/Neos.IdentityServer.MultiFactor.Provider.cs
@@ -887,7 +887,12 @@ namespace Neos.IdentityServer.MultiFactor
                             usercontext.PreferredMethod = PreferredMethod.Email;
                             string stmail = proofData.Properties["stmail"].ToString();
                             string idom = MailUtilities.StripEmailDomain(usercontext.MailAddress);
-                            if ((stmail.ToLower() + idom.ToLower()).Equals(usercontext.MailAddress.ToLower()) && (Utilities.ValidateEmail(usercontext.MailAddress, true)))
+                            string fullmail = stmail.ToLower();
+                            if (!fullmail.Contains("@"))
+                            {
+                                fullmail += idom.ToLower();
+                            }
+                            if (fullmail.Equals(usercontext.MailAddress.ToLower()) && (Utilities.ValidateEmail(usercontext.MailAddress, true)))
                             {
                                 usercontext.UIMode = GetAuthenticationContextRequest(usercontext);
                                 result = new AdapterPresentation(this, context);


### PR DESCRIPTION
The code currently assumes the user provides only the user part of the
e-mail address and unconditionally appends the known domain to the user
provided data.

This results in an error message when the user specifies the full e-mail
address.

Only append the domain when no '@' is present in the user provided data.